### PR TITLE
Display footer info as list instead of columns

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,8 @@
   "env": {
     "browser": true,
     "node": true,
-    "mocha": true
+    "mocha": true,
+    "jest": true
   },
   "globals": {
     "__DEV__": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.3] - 2018-10-11
+
 ### Fixed
 - Display store info as list instead of columns in mobile.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Display store info as list instead of columns in mobile.
+
 ## [1.0.2] - 2018-09-27
 ### Fixed
 - Removed call to `console.log`.

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore-footer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "title": "VTEX Footer component",
   "defaultLocale": "pt-BR",
   "description": "The canonical VTEX footer component",

--- a/react/index.js
+++ b/react/index.js
@@ -257,7 +257,7 @@ export default class Footer extends Component {
               storeInformations.map(({ storeInformation }, index) => (
                 <div
                   key={`information-${index}`}
-                  className="vtex-footer__text-information w-50 f7 ph3"
+                  className="vtex-footer__text-information w-100 w-50-ns pa3 f7"
                 >
                   {storeInformation}
                 </div>


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the footer info view in mobile.

#### What problem is this solving?
The store info was being displayed as columns in mobile, now they being displayed as a list.

#### How should this be manually tested?
https://fixfooterinfo--storecomponents.myvtex.com/
Select the mobile option in the developer view.

#### Screenshots or example usage
![capture](https://user-images.githubusercontent.com/4912690/46550199-b0bd6d80-c8aa-11e8-85ea-67461b585da4.PNG)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

