### PR TITLE
Fix/sectiontitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [1.0.4] - 2018-10-15
 ### Fixed
 - Fixed sections title's and spacing of social network's icons
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix sections not showing and social networks spacing
+- Fix section titles not showing and social networks spacing
 
 ## [1.0.3] - 2018-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix sections not showing and social networks spacing
 
 ## [1.0.3] - 2018-10-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix section titles not showing and social networks spacing
+- Fixed sections title's and spacing of social network's icons
 
 ## [1.0.3] - 2018-10-11
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "dreamstore-footer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "title": "VTEX Footer component",
   "defaultLocale": "pt-BR",
   "description": "The canonical VTEX footer component",

--- a/react/components/Accordion.js
+++ b/react/components/Accordion.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Collapse } from 'react-collapse'
-import { injectIntl, intlShape } from 'react-intl'
+import { injectIntl, intlShape, FormattedMessage } from 'react-intl'
 import { IconCaretDown, IconCaretRight } from 'vtex.styleguide'
 
 class Accordion extends Component {
@@ -32,7 +32,7 @@ class Accordion extends Component {
           <div>
             {title && (
               <span className="vtex-footer__accordion-title dib ma0 ttu">
-                {this.props.intl.messages[title] && this.props.intl.formatMessage({ id: title })}
+                <FormattedMessage id={title} defaultMessage={title} />
               </span>
             )}
             <span className="vtex-footer__accordion-icon fr">

--- a/react/components/FooterSocialNetworkList.js
+++ b/react/components/FooterSocialNetworkList.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types'
-import React, { Component } from 'react'
+import React from 'react'
 
 import footerList from './footerList'
 import withImage from './withImage'
@@ -22,6 +22,8 @@ const FooterSocialNetworkItem = ({ imageSrc, url }) => {
 FooterSocialNetworkItem.displayName = 'FooterSocialNetworkItem'
 
 FooterSocialNetworkItem.propTypes = {
+  /** Social network icon source */
+  imageSrc: PropTypes.string,
   /** For which link should the user be redirected if the image is clicked */
   url: PropTypes.string,
   /** If true, the original logo (with color) is used. If not, the grayscale's one */

--- a/react/components/FooterSocialNetworkList.js
+++ b/react/components/FooterSocialNetworkList.js
@@ -13,7 +13,7 @@ const FooterSocialNetworkItem = ({ imageSrc, url }) => {
   }
 
   return (
-    <a href={url} target="_blank" className="mid-gray">
+    <a href={url} target="_blank" className="mid-gray pointer">
       <img className="vtex-footer__social-network-item" src={imageSrc} />
     </a>
   )

--- a/react/index.js
+++ b/react/index.js
@@ -233,7 +233,7 @@ export default class Footer extends Component {
           <div className="vtex-footer__links-container f6 w-100-s w-80-ns">
             <FooterLinksMatrix links={sectionLinks} />
           </div>
-          <div className="vtex-footer__social-networks-container pa1 pt0 relative">
+          <div className="vtex-footer__social-networks-container pa1 mt0-ns mt7 relative">
             <FooterSocialNetworkList
               titleId="social-networks"
               list={socialNetworks}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fix the social networks spacing and the section titles in mobile.

#### What problem is this solving?
The section titles were not being shown and the social networks spacing was wrong.
Also, the mouse cursor didn't change in the social network logos (now it becomes a hand) and the propType for the social networks image sources was missing.

#### How should this be manually tested?
https://fixsectiontitles--storecomponents.myvtex.com/
Hover over the social networks icons.
Select the mobile option in the developer view to test the spacing and the sections.

#### Screenshots or example usage
![capture](https://user-images.githubusercontent.com/4912690/46612708-bc49a800-cae7-11e8-9f29-e445269b88f3.PNG)

#### Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

