### PR TITLE
Center using vtex-page-padding class instead of tachyons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix paddings to match page and header
 
 ## [1.0.7] - 2018-10-31
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- Fix paddings to match page and header
+- Center using vtex-page-padding class instead of tachyons.
 
 ## [1.0.7] - 2018-10-31
 ### Fixed

--- a/react/components/FooterPaymentFormMatrix.js
+++ b/react/components/FooterPaymentFormMatrix.js
@@ -23,7 +23,7 @@ export default class FooterPaymentFormMatrix extends Component {
 
     return (
       paymentForms && (
-        <div className="vtex-footer__matrix-container vtex-footer__payment-matrix-container flex flex-wrap">
+        <div className="vtex-footer__matrix-container vtex-footer__payment-matrix-container flex flex-wrap pl3-ns">
           {paymentForms.map((paymentFormsItem, index) => (
             <div
               key={`payment-container-${index}`}

--- a/react/components/FooterPaymentFormMatrix.js
+++ b/react/components/FooterPaymentFormMatrix.js
@@ -23,7 +23,7 @@ export default class FooterPaymentFormMatrix extends Component {
 
     return (
       paymentForms && (
-        <div className="vtex-footer__matrix-container vtex-footer__payment-matrix-container flex flex-wrap pl3-ns">
+        <div className="vtex-footer__matrix-container vtex-footer__payment-matrix-container flex flex-wrap pl4-ns">
           {paymentForms.map((paymentFormsItem, index) => (
             <div
               key={`payment-container-${index}`}

--- a/react/components/FooterVtexLogo.js
+++ b/react/components/FooterVtexLogo.js
@@ -12,7 +12,7 @@ const FooterVtexLogo = ({ logoUrl, imageSrc }) => {
   }
 
   return (
-    <div className="vtex-footer__badge-list  vtex-footer__list-container--right-aligned flex flex-row justify-center pv4-s pa0-ns items-center ml-auto-m">
+    <div className="vtex-footer__badge-list pr3-ns  vtex-footer__list-container--right-aligned flex flex-row justify-center pv4-s pa0-ns items-center ml-auto-m">
       <span className="vtex-footer__badge pa2-s pa1-ns">
         <img className="vtex-footer__logo-image h3" src={logoUrl} />
       </span>

--- a/react/components/FooterVtexLogo.js
+++ b/react/components/FooterVtexLogo.js
@@ -12,7 +12,7 @@ const FooterVtexLogo = ({ logoUrl, imageSrc }) => {
   }
 
   return (
-    <div className="vtex-footer__badge-list pr3-ns  vtex-footer__list-container--right-aligned flex flex-row justify-center pv4-s pa0-ns items-center ml-auto-m">
+    <div className="vtex-footer__badge-list pr4-ns  vtex-footer__list-container--right-aligned flex flex-row justify-center pv4-s pa0-ns items-center ml-auto-m">
       <span className="vtex-footer__badge pa2-s pa1-ns">
         <img className="vtex-footer__logo-image h3" src={logoUrl} />
       </span>

--- a/react/global.css
+++ b/react/global.css
@@ -13,15 +13,24 @@
   }
 }
 
-@media screen and (min-width: 40em) {
+@media only screen and (max-width: 40em) {
   .vtex-footer__container {
+    padding-left: 1.25rem;
+    padding-right: 1.25rem;
+  }
+}
+
+@media only screen and (min-width: 40em) {
+  .vtex-footer__container {
+    padding-left: 3.25rem;
+    padding-right: 3.25rem;
     flex-flow: row wrap;
   }
 }
 
-@media screen and (min-width: 64em) {
+@media only screen and (min-width: 64em) {
   .vtex-footer__container {
-    padding: 20px 70px 20px;
+    padding: 20px 4.375em 20px 4.375em;
   }
 
   .vtex-footer__container:first-of-type {
@@ -35,22 +44,8 @@
 
 @media screen and (min-width: 80em) {
   .vtex-footer__container {
-    padding-left: 140px;
-    padding-right: 140px;
-  }
-}
-
-@media screen and (min-width: 100em) {
-  .vtex-footer__container {
-    padding-left: 250px;
-    padding-right: 250px;
-  }
-}
-
-@media screen and (min-width: 120em) {
-  .vtex-footer__container {
-    padding-left: 320px;
-    padding-right: 320px;
+    padding-left: 8.75rem;
+    padding-right: 8.75rem;
   }
 }
 

--- a/react/global.css
+++ b/react/global.css
@@ -13,41 +13,24 @@
   }
 }
 
-@media only screen and (min-width: 20em) {
-  .vtex-footer__container {
-    padding-left: .5rem;
-    padding-right: .5rem;
-  }
-}
-
 @media only screen and (min-width: 40em) {
   .vtex-footer__container {
-    padding-left: 2rem;
-    padding-right: 2rem;
     flex-flow: row wrap;
   }
 }
 
 @media only screen and (min-width: 64em) {
   .vtex-footer__container {
-    width: 90%;
-    padding-top: 20px;
-    padding-bottom: 20px;
+    padding-top: 1.25rem;
+    padding-bottom: 1.25rem;
   }
 
   .vtex-footer__container:first-of-type {
-    padding-top: 25px;
+    padding-top: 1.5625rem;
   }
 
   .vtex-footer__container:last-of-type {
-    padding-bottom: 25px;
-  }
-}
-
-@media screen and (min-width: 80em) {
-  .vtex-footer__container {
-    padding-left: 1.5rem;
-    padding-right: 1.5rem;
+    padding-bottom: 1.5625rem;
   }
 }
 

--- a/react/global.css
+++ b/react/global.css
@@ -13,24 +13,26 @@
   }
 }
 
-@media only screen and (max-width: 40em) {
+@media only screen and (min-width: 20em) {
   .vtex-footer__container {
-    padding-left: 1.25rem;
-    padding-right: 1.25rem;
+    padding-left: .5rem;
+    padding-right: .5rem;
   }
 }
 
 @media only screen and (min-width: 40em) {
   .vtex-footer__container {
-    padding-left: 3.25rem;
-    padding-right: 3.25rem;
+    padding-left: 2rem;
+    padding-right: 2rem;
     flex-flow: row wrap;
   }
 }
 
 @media only screen and (min-width: 64em) {
   .vtex-footer__container {
-    padding: 20px 4.375em 20px 4.375em;
+    width: 90%;
+    padding-top: 20px;
+    padding-bottom: 20px;
   }
 
   .vtex-footer__container:first-of-type {
@@ -44,8 +46,8 @@
 
 @media screen and (min-width: 80em) {
   .vtex-footer__container {
-    padding-left: 8.75rem;
-    padding-right: 8.75rem;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
   }
 }
 

--- a/react/index.js
+++ b/react/index.js
@@ -246,7 +246,7 @@ export default class Footer extends Component {
 
     return (
       <footer className="vtex-footer bt bw1 b--muted-4 mt4 pv5">
-        <div className="vtex-footer__container center pt5-s flex justify-between ph4-s bg-white mid-gray">
+        <div className="vtex-footer__container center pt5-s flex justify-between w-90-l ph6-xl ph7-m ph3-s bg-white mid-gray">
           <div className="vtex-footer__links-container f6 w-100-s w-80-ns pb5-s pl3-ns">
             <FooterLinksMatrix links={sectionLinks} />
           </div>
@@ -261,14 +261,14 @@ export default class Footer extends Component {
             />
           </div>
         </div>
-        <div className="vtex-footer__container center pv5-s flex justify-between ph4-s bg-white mid-gray">
+        <div className="vtex-footer__container center pv5-s flex justify-between w-90-l ph6-xl ph7-m ph3-s bg-white mid-gray">
           <FooterPaymentFormMatrix
             paymentForms={paymentForms}
             horizontal
             showInColor={showPaymentFormsInColor}
           />
         </div>
-        <div className="vtex-footer__container center pt5-s flex justify-between bg-white mid-gray ph4-s">
+        <div className="vtex-footer__container center pt5-s flex justify-between w-90-l ph6-xl ph7-m ph3-s bg-white mid-gray">
           <div className="vtex-footer__text-container w-100-s pb5-s w-80-ns flex flex-wrap">
             {storeInformations &&
               storeInformations.map(({ storeInformation }, index) => (

--- a/react/index.js
+++ b/react/index.js
@@ -246,7 +246,7 @@ export default class Footer extends Component {
 
     return (
       <footer className="vtex-footer bt bw1 b--muted-4 mt4 pv5">
-        <div className="vtex-footer__container pt5-s flex justify-between ph4-s bg-white mid-gray">
+        <div className="vtex-footer__container center pt5-s flex justify-between ph4-s bg-white mid-gray">
           <div className="vtex-footer__links-container f6 w-100-s w-80-ns pb5-s">
             <FooterLinksMatrix links={sectionLinks} />
           </div>
@@ -261,14 +261,14 @@ export default class Footer extends Component {
             />
           </div>
         </div>
-        <div className="vtex-footer__container pv5-s flex justify-between ph4-s bg-white mid-gray">
+        <div className="vtex-footer__container center pv5-s flex justify-between ph4-s bg-white mid-gray">
           <FooterPaymentFormMatrix
             paymentForms={paymentForms}
             horizontal
             showInColor={showPaymentFormsInColor}
           />
         </div>
-        <div className="vtex-footer__container pt5-s flex justify-between bg-white mid-gray ph4-s">
+        <div className="vtex-footer__container center pt5-s flex justify-between bg-white mid-gray ph4-s">
           <div className="vtex-footer__text-container w-100-s pb5-s w-80-ns flex flex-wrap">
             {storeInformations &&
               storeInformations.map(({ storeInformation }, index) => (

--- a/react/index.js
+++ b/react/index.js
@@ -218,7 +218,7 @@ export default class Footer extends Component {
 
   getInformationCssClasses = (listLength, index) => {
     let paddingClass
-    const defaultClasses = 'vtex-footer__text-information w-100 w-50-ns pa3-ns f7 ma0'
+    const defaultClasses = 'vtex-footer__text-information w-100 w-50-ns pl4-ns pa3-ns f7 ma0'
     // Only apply vertical paddings if there is more than 1 element
     if (listLength > 1) {
       if (index === 0) {
@@ -247,10 +247,10 @@ export default class Footer extends Component {
     return (
       <footer className="vtex-footer bt bw1 b--muted-4 mt4 pv5">
         <div className="vtex-footer__container vtex-page-padding center pt5-s flex justify-between bg-white mid-gray">
-          <div className="vtex-footer__links-container f6 w-100-s w-80-ns pb5-s pl3-ns">
+          <div className="vtex-footer__links-container f6 w-100-s w-80-ns pb5-s pl4-ns">
             <FooterLinksMatrix links={sectionLinks} />
           </div>
-          <div className="vtex-footer__social-networks-container pv5-s pa1-ns">
+          <div className="vtex-footer__social-networks-container pv5-s pa1-ns pr2-ns">
             <FooterSocialNetworkList
               titleId="social-networks"
               list={socialNetworks}

--- a/react/index.js
+++ b/react/index.js
@@ -246,7 +246,7 @@ export default class Footer extends Component {
 
     return (
       <footer className="vtex-footer bt bw1 b--muted-4 mt4 pv5">
-        <div className="vtex-footer__container center pt5-s flex justify-between w-90-l ph6-xl ph7-m ph3-s bg-white mid-gray">
+        <div className="vtex-footer__container vtex-page-padding center pt5-s flex justify-between bg-white mid-gray">
           <div className="vtex-footer__links-container f6 w-100-s w-80-ns pb5-s pl3-ns">
             <FooterLinksMatrix links={sectionLinks} />
           </div>
@@ -261,14 +261,14 @@ export default class Footer extends Component {
             />
           </div>
         </div>
-        <div className="vtex-footer__container center pv5-s flex justify-between w-90-l ph6-xl ph7-m ph3-s bg-white mid-gray">
+        <div className="vtex-footer__container vtex-page-padding center pv5-s flex justify-between bg-white mid-gray">
           <FooterPaymentFormMatrix
             paymentForms={paymentForms}
             horizontal
             showInColor={showPaymentFormsInColor}
           />
         </div>
-        <div className="vtex-footer__container center pt5-s flex justify-between w-90-l ph6-xl ph7-m ph3-s bg-white mid-gray">
+        <div className="vtex-footer__container vtex-page-padding center pt5-s flex justify-between bg-white mid-gray">
           <div className="vtex-footer__text-container w-100-s pb5-s w-80-ns flex flex-wrap">
             {storeInformations &&
               storeInformations.map(({ storeInformation }, index) => (

--- a/react/index.js
+++ b/react/index.js
@@ -247,7 +247,7 @@ export default class Footer extends Component {
     return (
       <footer className="vtex-footer bt bw1 b--muted-4 mt4 pv5">
         <div className="vtex-footer__container center pt5-s flex justify-between ph4-s bg-white mid-gray">
-          <div className="vtex-footer__links-container f6 w-100-s w-80-ns pb5-s">
+          <div className="vtex-footer__links-container f6 w-100-s w-80-ns pb5-s pl3-ns">
             <FooterLinksMatrix links={sectionLinks} />
           </div>
           <div className="vtex-footer__social-networks-container pv5-s pa1-ns">


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adjust paddings on vtex-footer_container to match header and vtex-page-padding

#### What problem is this solving?
Adjustments in order to provide a consistent overall padding

#### How should this be manually tested?
[Access this workspace](https://alignheader--storecomponents.myvtex.com/)

#### Screenshots or example usage
![shoot](https://user-images.githubusercontent.com/6964311/47804697-37336680-dd14-11e8-9c3c-2c64fdc74f35.png)

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

